### PR TITLE
Check if connection is alive or not

### DIFF
--- a/mailie/_client.py
+++ b/mailie/_client.py
@@ -196,6 +196,13 @@ class Client(BaseSMTPClient):
     @staticmethod
     def _build_request(*, email: Email, auth: typing.Optional[SMTP_AUTH_ALIAS] = None) -> Request:
         return Request(email=email, auth=auth)
+    
+    def is_connected(self) -> bool:
+        try:
+            status = self._delegate_client.noop()[0]
+        except:
+            status = -1
+        return True if status == 250 else False
 
 
 class AsyncClient(BaseSMTPClient):


### PR DESCRIPTION
Added function to check is connection is alive or not. 
The `noop` command is similar to `ping`. The `noop` return the SMTP connection status. 
 
**Mailie**  package may require this functionality in future use.